### PR TITLE
Tidied code, added .NET runtime version to generated filename

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -7,8 +7,8 @@ Licensed under GPL - see COPYING.txt
 
 
 Update:
-Whenever it comes across a new macrodef, it will SHA the content to generate a unique identifier. If a dll with that name exists in the temp directory, it will use that dll instead of recompiling it. If not, it will compile the macrodef and save it with the unique identifier.
+Whenever it comes across a new macrodef, it will SHA the content to generate a unique identifier. If a DLL with that name exists in the temp directory, it will use that DLL instead of recompiling it. If not, it will compile the macrodef and save it with the unique identifier.
 
 What this means is that all macrodefs will be compiled only once and should be significantly faster to load. It should detect changes and recompile them automatically.
 
-If you need to delete the cached dlls, you'll find them in %temp% ending with *_mdef.dll.
+If you need to delete the cached DLLs, you'll find them in %temp% prefixed with "mdef_"

--- a/default.build
+++ b/default.build
@@ -1,76 +1,75 @@
 <?xml version="1.0" ?>
 <project name="exoftware.nant" default="test" xmlns="http://nant.sf.net/schemas/nant.xsd">
-	<property name="build.dir" value="build" />
+  <property name="build.dir" value="build" />
 
-	<!-- User targets -->
-	<target name="clean" description="Delete Automated Build artifacts">
-		<delete dir="${build.dir}" if="${directory::exists(build.dir)}"/>
-		<delete dir="bin" if="${directory::exists('bin')}"/>
-		<delete dir="obj" if="${directory::exists('obj')}"/>
-	</target>
-	
-	<target name="compile" description="Compiles using the AutomatedDebug Configuration">
-		<echo message="${nant::get-base-directory()}" />
-		<mkdir dir="build"/>
-		<csc target="library" output="build/Macrodef.dll" debug="true" doc="build/Macrodef.xml">
-		    <sources>
-			<include name="src/*.cs" />
-		    </sources>
-		    <references>
-			<include name="System.dll" />
-			<include name="System.Data.dll" />
-		        <include name="${nant::get-base-directory()}/*.dll" />
-		    </references>
-		</csc>
-	</target>
-	
-	<target name="full" depends="clean, test, dist"	description="Compiles, tests, and produces distributions" />
-	
-	<target name="dist" depends="doc">
-	</target>
-	
-	<target name="test" depends="compile">
-		<nant buildfile="test/tests.build"/>
-	</target>
-	
-	<target name="doc" depends="compile">
-	<!-- use vs.net to build before running this -->
-	<property name="link.sdkdoc.version" value="SDK_v1_1" />
-        <property name="link.sdkdoc.web" value="true" />
-        <ndoc>
-            <assemblies basedir="build">
-                <include name="*.dll" />
-            </assemblies>
-	    <summaries basedir="build">
-		<include name="*.xml" />
-	    </summaries>
-            <documenters>
-                <documenter name="NAnt">
-                    <property name="OutputDirectory" value="build/doc" />
-                    <property name="SdkDocVersion" value="${link.sdkdoc.version}" />
-                    <property name="SdkLinksOnWeb" value="${link.sdkdoc.web}" />
-                    <!-- set base uri used for linking to other NAnt docs -->
-                    <property name="NAntBaseUri" value="../" />
-                    <!-- do not filter on namespace -->
-                    <property name="NamespaceFilter" value="" />
-                    <property name="ProductName" value="NAnt macrodef" />
-                    <property name="ProductVersion" value="0.1.0" />
-		    <property name="ProductUrl" value="http://peelmeagrape.net/" />                        
-                    <property name="Preliminary" value="True" />
-                    <property name="DocumentAttributes" value="True" />
-                    <property name="IncludeAssemblyVersion" value="True" />
-                    <property name="ShowMissingParams" value="True" />
-                    <property name="ShowMissingReturns" value="True" />
-                    <property name="ShowMissingValues" value="True" />
-                </documenter>
-            </documenters>
-        </ndoc>
-	<copy todir="build/">
-            <fileset>
-                <include name="doc/**" />
-            </fileset>
-        </copy>
-    </target>
-	
+  <!-- User targets -->
+  <target name="clean" description="Delete Automated Build artifacts">
+    <delete dir="${build.dir}" if="${directory::exists(build.dir)}"/>
+    <delete dir="bin" if="${directory::exists('bin')}"/>
+    <delete dir="obj" if="${directory::exists('obj')}"/>
+  </target>
+
+  <target name="compile" description="Compiles using the AutomatedDebug Configuration">
+    <echo message="${nant::get-base-directory()}" />
+    <mkdir dir="build"/>
+    <csc target="library" output="build/Macrodef.dll" debug="true" doc="build/Macrodef.xml">
+      <sources>
+        <include name="src/*.cs" />
+      </sources>
+      <references>
+        <include name="System.dll" />
+        <include name="System.Data.dll" />
+        <include name="${nant::get-base-directory()}/*.dll" />
+      </references>
+    </csc>
+  </target>
+
+  <target name="full" depends="clean, test, dist"	description="Compiles, tests, and produces distributions" />
+
+  <target name="dist" depends="doc" />
+
+  <target name="test" depends="compile">
+    <nant buildfile="test/tests.build"/>
+  </target>
+
+  <target name="doc" depends="compile">
+    <!-- use vs.net to build before running this -->
+    <property name="link.sdkdoc.version" value="SDK_v1_1" />
+    <property name="link.sdkdoc.web" value="true" />
+    <ndoc>
+      <assemblies basedir="build">
+        <include name="*.dll" />
+      </assemblies>
+      <summaries basedir="build">
+        <include name="*.xml" />
+      </summaries>
+      <documenters>
+        <documenter name="NAnt">
+          <property name="OutputDirectory" value="build/doc" />
+          <property name="SdkDocVersion" value="${link.sdkdoc.version}" />
+          <property name="SdkLinksOnWeb" value="${link.sdkdoc.web}" />
+          <!-- set base uri used for linking to other NAnt docs -->
+          <property name="NAntBaseUri" value="../" />
+          <!-- do not filter on namespace -->
+          <property name="NamespaceFilter" value="" />
+          <property name="ProductName" value="NAnt macrodef" />
+          <property name="ProductVersion" value="0.1.0" />
+          <property name="ProductUrl" value="http://peelmeagrape.net/" />
+          <property name="Preliminary" value="True" />
+          <property name="DocumentAttributes" value="True" />
+          <property name="IncludeAssemblyVersion" value="True" />
+          <property name="ShowMissingParams" value="True" />
+          <property name="ShowMissingReturns" value="True" />
+          <property name="ShowMissingValues" value="True" />
+        </documenter>
+      </documenters>
+    </ndoc>
+    <copy todir="build/">
+      <fileset>
+        <include name="doc/**" />
+      </fileset>
+    </copy>
+  </target>
+
 </project>
 

--- a/doc/style.css
+++ b/doc/style.css
@@ -209,5 +209,5 @@ p.topicstatus {
 }
 
 ul.examples {
-	list-style-type: lower-roman;
+    list-style-type: lower-roman;
 }

--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Reflection;
 [assembly : AssemblyTrademark("")]
 [assembly : AssemblyCulture("")]
 
-[assembly : AssemblyVersion("0.1.0.*")]
+[assembly : AssemblyVersion("0.2.0.*")]
 
 [assembly : AssemblyDelaySign(false)]
 [assembly : AssemblyKeyFile("")]

--- a/src/AssertFailTask.cs
+++ b/src/AssertFailTask.cs
@@ -4,41 +4,42 @@ using NAnt.Core.Attributes;
 
 namespace Macrodef
 {
-	/// <summary>
-	/// Makes sure that the nested block fails. Used in tests of macrodef.
-	/// </summary>
-	[TaskName("assert-fail")]
-	public class AssertFailTask : TaskContainer
-	{
-		private string message = "Block expected to fail";
-		
-		/// <summary>
-		/// Optional error message - thrown if nested block doesn't fail.
-		/// </summary>
-		[TaskAttribute("message")]
-		public string Message
-		{
-			get { return message; }
-			set { message = value; }
-		}
+    /// <summary>
+    /// Makes sure that the nested block fails. Used in tests of macrodef.
+    /// </summary>
+    [TaskName("assert-fail")]
+    public class AssertFailTask : TaskContainer
+    {
+        public AssertFailTask()
+        {
+            Message = "Block expected to fail";
+        }
 
-		protected override void ExecuteTask()
-		{
-			bool failed = false;
-			try
-			{
-				base.ExecuteTask();
-			}
-			catch(Exception e)
-			{
-				Log(Level.Info, "Expected exception: " + e.Message);
-				Log(Level.Verbose, "Expected exception _was_ thrown: " + e);
-				failed = true;
-			}
-			if(!failed)
-			{
-				throw new BuildException(message);
-			}
-		}
-	}
+        /// <summary>
+        /// Optional error message - thrown if nested block doesn't fail.
+        /// </summary>
+        [TaskAttribute("message")]
+        public string Message { get; set; }
+
+        protected override void ExecuteTask()
+        {
+            var failed = false;
+
+            try
+            {
+                base.ExecuteTask();
+            }
+            catch (Exception e)
+            {
+                failed = true;
+                Log(Level.Info, "Expected exception: " + e.Message);
+                Log(Level.Verbose, "Expected exception _was_ thrown: " + e);
+            }
+
+            if (!failed)
+            {
+                throw new BuildException(Message);
+            }
+        }
+    }
 }

--- a/src/MacroAttribute.cs
+++ b/src/MacroAttribute.cs
@@ -9,48 +9,33 @@ namespace Macrodef
 	[ElementName("attribute")]
 	public class MacroAttribute : Element
 	{
-		/// <summary>
-		/// The name of the attribute.
-		/// </summary>
-		[TaskAttribute("name")]
-		public string name
-		{
-			get { return _name; }
-			set { _name = value; }
-		}
+	    /// <summary>
+	    /// The name of the attribute.
+	    /// </summary>
+	    [TaskAttribute("name")]
+	    public string AttributeName { get; set; }
 
-		/// <summary>
-		/// Property name to store the value in - defaults to the name of the attribute.
-		/// </summary>
-		[TaskAttribute("property")]
-		public string property
-		{
-			get { return _property; }
-			set { _property = value; }
-		}
+	    /// <summary>
+	    /// Property name to store the value in - defaults to the name of the attribute.
+	    /// </summary>
+	    [TaskAttribute("property")]
+	    public string Property { get; set; }
 
-		public string LocalPropertyName
+	    /// <summary>
+	    /// Default value - the property will be set to this if the attribute is not present.
+	    /// </summary>
+	    [TaskAttribute("default")]
+	    public string DefaultValue { get; set; }
+
+	    public string LocalPropertyName
 		{
 			get
 			{
-				if (_property == null)
-					return _name;
-				return _property;
+				if (Property == null)
+					return AttributeName;
+
+				return Property;
 			}
 		}
-
-		/// <summary>
-		/// Default value - the property will be set to this if the attribute is not present.
-		/// </summary>
-		[TaskAttribute("default")]
-		public string defaultValue
-		{
-			get { return _default; }
-			set { _default = value; }
-		}
-
-		private string _name;
-		private string _default;
-		private string _property;
 	}
 }

--- a/src/MacroDefTask.cs
+++ b/src/MacroDefTask.cs
@@ -178,7 +178,7 @@ namespace Macrodef
             if (string.IsNullOrEmpty(_contentHash))
                 _contentHash = GenerateHash(_macrodefNode);
 
-            return string.Format("{0}_{1}_mdef", TaskName, _contentHash);
+            return string.Format("mdef_{0}_{1}", TaskName, _contentHash);
         }
 
         // Create a hash from the definition of the macrodef and return it

--- a/src/MacroElement.cs
+++ b/src/MacroElement.cs
@@ -9,16 +9,10 @@ namespace Macrodef
 	[ElementName("element")]
 	public class MacroElement : Element
 	{
-		/// <summary>
-		/// The name of the element.
-		/// </summary>
-		[TaskAttribute("name")]
-		public string name
-		{
-			get { return _name; }
-			set { _name = value; }
-		}
-
-		private string _name;
+	    /// <summary>
+	    /// The name of the element.
+	    /// </summary>
+	    [TaskAttribute("name")]
+	    public string ElementName { get; set; }
 	}
 }

--- a/src/SimpleCSharpCompiler.cs
+++ b/src/SimpleCSharpCompiler.cs
@@ -4,118 +4,118 @@ using System.CodeDom.Compiler;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
+using System.Text;
 using NAnt.Core;
 using NAnt.Core.Util;
 
 namespace Macrodef
 {
-	// adapted from <script> task
-	internal class SimpleCSharpCompiler
-	{
-	    private readonly string uniqueIdentifier;
+    // adapted from <script> task
+    internal class SimpleCSharpCompiler
+    {
+        private readonly string _uniqueIdentifier;
+        private readonly CodeDomProvider _provider;
 
-	    public SimpleCSharpCompiler(string UniqueIdentifier)
-		{
-		    uniqueIdentifier = UniqueIdentifier;
-		    Provider = CreateCodeDomProvider("Microsoft.CSharp.CSharpCodeProvider", "System");
-			//Compiler = provider.CreateCompiler();
-			//CodeGen = provider.CreateGenerator();
-		}
+        public SimpleCSharpCompiler(string uniqueIdentifier)
+        {
+            _uniqueIdentifier = uniqueIdentifier;
+            _provider = CreateCodeDomProvider("Microsoft.CSharp.CSharpCodeProvider", "System");
+        }
 
-	    //public readonly ICodeCompiler Compiler;
-		//public readonly ICodeGenerator CodeGen;
-		public readonly CodeDomProvider Provider;
+        public string PreCompiledDllPath
+        {
+            get { return OutputDllPath(_uniqueIdentifier); }
+        }
 
-	    public string PreCompiledDllPath
-	    {
-            get { return OuptutDllPath(uniqueIdentifier); }
-	    }
+        public string GetSourceCode(CodeCompileUnit compileUnit)
+        {
+            var sw = new StringWriter(CultureInfo.InvariantCulture);
 
-		public string GetSourceCode(CodeCompileUnit compileUnit)
-		{
-			StringWriter sw = new StringWriter(CultureInfo.InvariantCulture);
+            _provider.GenerateCodeFromCompileUnit(compileUnit, sw, null);
 
-			Provider.GenerateCodeFromCompileUnit(compileUnit, sw, null);
-			return sw.ToString();
-		}
+            return sw.ToString();
+        }
 
-		private static CompilerParameters CreateCompilerOptions(string uniqueIdentifier)
-		{
-			CompilerParameters options = new CompilerParameters();
-			options.GenerateExecutable = false;
-			// <script> task uses true - and hence doesn't work properly (second script that contains task defs fails)!
-			options.GenerateInMemory = false;
-		    options.OutputAssembly = OuptutDllPath(uniqueIdentifier);
-			foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
-			{
-				try
-				{
-					if (!StringUtils.IsNullOrEmpty(asm.Location))
-					{
-						options.ReferencedAssemblies.Add(asm.Location);
-					}
-				}
-				catch (NotSupportedException)
-				{
-					// Ignore - this error is sometimes thrown by asm.Location 
-					// for certain dynamic assemblies
-				}
-			}
-			return options;
-		}
+        private static CompilerParameters CreateCompilerOptions(string uniqueIdentifier)
+        {
+            var options = new CompilerParameters
+                {
+                    GenerateExecutable = false,
+                    GenerateInMemory = false, // <script> task uses true - and hence doesn't work properly (second script that contains task defs fails)!
+                    OutputAssembly = OutputDllPath(uniqueIdentifier)
+                };
 
-	    private static string OuptutDllPath(string uniqueIdentifier)
-	    {
-	        return Path.Combine(Path.GetTempPath(), uniqueIdentifier + ".dll");
-	    }
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                try
+                {
+                    if (!string.IsNullOrEmpty(asm.Location))
+                    {
+                        options.ReferencedAssemblies.Add(asm.Location);
+                    }
+                }
+                catch (NotSupportedException)
+                {
+                    // Ignore - this error is sometimes thrown by asm.Location 
+                    // for certain dynamic assemblies
+                }
+            }
 
-		public Assembly CompileAssembly(CodeCompileUnit compileUnit)
-		{
-			CompilerParameters options = CreateCompilerOptions(uniqueIdentifier);
+            return options;
+        }
 
-			CompilerResults results = Provider.CompileAssemblyFromDom(options, compileUnit);
+        private static string OutputDllPath(string name)
+        {
+            return Path.Combine(Path.GetTempPath(), name + ".dll");
+        }
 
-			Assembly compiled;
-			if (results.Errors.Count > 0)
-			{
-				string errors = "Errors:" + Environment.NewLine;
-				foreach (CompilerError err in results.Errors)
-				{
-					errors += err.ToString() + Environment.NewLine;
-				}
-				errors += GetSourceCode(compileUnit);
-				throw new BuildException(errors);
-			}
-			else
-			{
-				compiled = results.CompiledAssembly;
-			}
-			return compiled;
-		}
+        public Assembly CompileAssembly(CodeCompileUnit compileUnit)
+        {
+            var options = CreateCompilerOptions(_uniqueIdentifier);
+            var results = _provider.CompileAssemblyFromDom(options, compileUnit);
 
-		private static CodeDomProvider CreateCodeDomProvider(string typeName, string assemblyName)
-		{
-			Assembly providerAssembly = Assembly.Load(assemblyName);
-			if (providerAssembly == null)
-			{
-				throw new ArgumentException(string.Format(CultureInfo.InvariantCulture,
-				                                          ResourceUtils.GetString("NA2037"), assemblyName));
-			}
+            if (results.Errors.Count > 0)
+            {
+                var errors = new StringBuilder();
+                errors.AppendLine("Errors:");
+                
+                foreach (CompilerError err in results.Errors)
+                {
+                    errors.AppendLine(err.ToString());
+                }
 
-			Type providerType = providerAssembly.GetType(typeName, true, true);
+                errors.Append(GetSourceCode(compileUnit));
 
-			object provider = Activator.CreateInstance(providerType);
-			if (!(provider is CodeDomProvider))
-			{
-				throw new ArgumentException(string.Format(CultureInfo.InvariantCulture,
-				                                          ResourceUtils.GetString("NA2038"), providerType.FullName));
-			}
-			return (CodeDomProvider) provider;
-		}
+                throw new BuildException(errors.ToString());
+            }
 
-	    public bool PrecompiledDllExists()
-	    {
-	        return File.Exists(OuptutDllPath(uniqueIdentifier));
-	    }
-	}
+            return results.CompiledAssembly;
+        }
+
+        private static CodeDomProvider CreateCodeDomProvider(string typeName, string assemblyName)
+        {
+            var providerAssembly = Assembly.Load(assemblyName);
+            
+            if (providerAssembly == null)
+            {
+                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, ResourceUtils.GetString("NA2037"), assemblyName));
+            }
+
+            var providerType = providerAssembly.GetType(typeName, true, true);
+
+            var provider = Activator.CreateInstance(providerType);
+            
+            if (!(provider is CodeDomProvider))
+            {
+                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, ResourceUtils.GetString("NA2038"), providerType.FullName));
+            }
+
+            return (CodeDomProvider) provider;
+        }
+
+        public bool PrecompiledDllExists()
+        {
+            return File.Exists(OutputDllPath(_uniqueIdentifier));
+        }
+    }
 }

--- a/test/duplicate-redefinition.build
+++ b/test/duplicate-redefinition.build
@@ -10,6 +10,4 @@
       </sequential>
     </macrodef>
   </target>
-
 </project>
-

--- a/test/duplicate.build
+++ b/test/duplicate.build
@@ -8,4 +8,3 @@
 		</sequential>
 	</macrodef>
 </project>
-

--- a/test/tests.build
+++ b/test/tests.build
@@ -1,142 +1,141 @@
 <?xml version="1.0" ?>
 <project name="exoftware.nant" default="test" xmlns="http://nant.sf.net/schemas/nant.xsd">
-	<loadtasks assembly="../build/Macrodef.dll" verbose="true" />
-	
-	<macrodef name="assert-equals">
-		<attributes>
-			<attribute name="name"/>
-			<attribute name="expected"/>
-			<attribute name="actual"/>
-		</attributes>
-		<sequential>
-			<fail if="${ expected != actual}" message="${name}: expected '${expected}' but was '${actual}'"/>
-		</sequential>
-	</macrodef>
-	
-	<target name="test-macro-defined">
-		<macrodef name="empty-macro">
-			<sequential/>
-		</macrodef>
-		<empty-macro a="1" b="2"/>
-	</target>
-	
-	<target name="test-attributes">
-		<macrodef name="simple-macro">
-			<attributes>
-				<attribute name="a" property="propa"/>
-				<attribute name="b" property="propb" default="b"/>
-			</attributes>
-			<sequential>
-				<property name="actual_a" value="${propa}"/>
-				<property name="actual_b" value="${propb}"/>
-			</sequential>
-		</macrodef>
-
-		<simple-macro a="1" b="2"/>
-		<fail if="${ actual_a != '1'}" message="a: expected 1 but was ${actual_a}"/>
-		<fail if="${ actual_b != '2'}" message="b: expected 2 but was ${actual_b}"/>
-
-		<simple-macro a="1"/>
-		<fail if="${ actual_a != '1'}" message="a: expected 1 but was ${actual_a}"/>
-		<fail if="${ actual_b != 'b'}" message="b: expected b but was ${actual_b}"/>
-	</target>
-	
-	<target name="test-properties-backedup">
-		<macrodef name="store-old-values">
-			<attributes>
-				<attribute name="a"/>
-				<attribute name="b"/>
-			</attributes>
-			<sequential>
-				<property name="given_a" value="${a}"/>
-				<property name="given_b" value="${b}"/>
-			</sequential>
-		</macrodef>
-
-		<property name="a" value="1"/>
-		
-		<store-old-values a="2" b="b" />
-		<fail if="${ given_a != '2'}" message="given_a: expected 2 but was ${given_a}"/>
-		<fail if="${ a != '1'}" message="a: expected 1 but was ${a}"/>
-		
-		<fail if="${ given_b != 'b'}" message="given_b: expected b but was ${given_b}"/>
-		<fail if="${ property::exists('b')}" message="'b' should not exist outside macro"/>
-	</target>
-	
-	<target name="test-property-subst">
-		<macrodef name="property-subst">
-			<attributes>
-				<attribute name="a"/>
-			</attributes>
-			<sequential>
-				<property name="actual_a" value="${a}"/>
-				<property name="function_result" value="${bool::to-string(true)}"/>
-			</sequential>
-		</macrodef>
-
-		<property name="myprop" value="a"/>
-
-		<property-subst a="${myprop}"/>
-		<assert-equals name="a" expected="a" actual="${actual_a}"/>
-		<assert-equals name="function_result" expected="True" actual="${function_result}"/>
-	</target>
-	
-	<target name="test-elements">
-		<macrodef name="macro-with-elements">
-			<elements>
-				<element name="element1"/>
-			</elements>
-			<sequential>
-				<echo message="before element1"/>
-				<element1/>
-				<echo message="after element1"/>
-			</sequential>
-		</macrodef>
-
-		<macro-with-elements>
-			<element1>
-				<property name="element_executed" value="true"/>
-			</element1>
-		</macro-with-elements>
-		<fail if="${ element_executed != 'true'}" message="element_executed: expected true but was ${element_executed}"/>
-	</target>
-
-
-	<target name="test-duplicate-macrodef">
-		<!--Should not fail if the same macro is included twice-->
-		<nant buildfile="duplicate.build" />
-		<nant buildfile="duplicate.build" />
-	</target>
-
-	<target name="test-duplicate-macrodef-redefinition">
-		<exec program="nant" commandline="/f:duplicate-redefinition.build" resultproperty="redefinition.failed" failonerror="false"/>
-		<if test="${redefinition.failed=='0'}">
-			<fail message="Should have failed because we are trying to redefine an existing macro."/>
-		</if>
-	</target>
-
-	<include buildfile="macrodefinitions.build" />
+  <loadtasks assembly="../build/Macrodef.dll" verbose="true" />
   
-	<target name="test-element-from-different-context">
-		<elements-context-test>
-			<test-element>
-				<property name="test-element_executed" value="true"/>
-				<echo message ="This is a node from a different context"/>
-			</test-element>
-		</elements-context-test>
-		<fail if="${ test-element_executed != 'true'}" message="test-element_executed: expected true but was ${test-element_executed}"/>
-	</target>
-	
-	<target name="test" depends="
-			test-macro-defined,
-			test-attributes,
-			test-properties-backedup,
-			test-property-subst,
-			test-elements,
-			test-duplicate-macrodef,
-			test-duplicate-macrodef-redefinition,
-			test-element-from-different-context
-			"/>
-	
+  <macrodef name="assert-equals">
+    <attributes>
+      <attribute name="name" />
+      <attribute name="expected" />
+      <attribute name="actual" />
+    </attributes>
+    <sequential>
+      <fail if="${expected != actual}" message="${name}: expected '${expected}' but was '${actual}'" />
+    </sequential>
+  </macrodef>
+  
+  <target name="test-macro-defined">
+    <macrodef name="empty-macro">
+      <sequential />
+    </macrodef>
+    <empty-macro a="1" b="2" />
+  </target>
+  
+  <target name="test-attributes">
+    <macrodef name="simple-macro">
+      <attributes>
+        <attribute name="a" property="propa" />
+        <attribute name="b" property="propb" default="b" />
+      </attributes>
+      <sequential>
+        <property name="actual_a" value="${propa}" />
+        <property name="actual_b" value="${propb}" />
+      </sequential>
+    </macrodef>
+
+    <simple-macro a="1" b="2" />
+    <fail if="${actual_a != '1'}" message="a: expected 1 but was ${actual_a}" />
+    <fail if="${actual_b != '2'}" message="b: expected 2 but was ${actual_b}" />
+
+    <simple-macro a="1" />
+    <fail if="${actual_a != '1'}" message="a: expected 1 but was ${actual_a}" />
+    <fail if="${actual_b != 'b'}" message="b: expected b but was ${actual_b}" />
+  </target>
+  
+  <target name="test-properties-backedup">
+    <macrodef name="store-old-values">
+      <attributes>
+        <attribute name="a" />
+        <attribute name="b" />
+      </attributes>
+      <sequential>
+        <property name="given_a" value="${a}" />
+        <property name="given_b" value="${b}" />
+      </sequential>
+    </macrodef>
+
+    <property name="a" value="1" />
+    
+    <store-old-values a="2" b="b" />
+    <fail if="${given_a != '2'}" message="given_a: expected 2 but was ${given_a}" />
+    <fail if="${a != '1'}" message="a: expected 1 but was ${a}"/>
+    
+    <fail if="${given_b != 'b'}" message="given_b: expected b but was ${given_b}" />
+    <fail if="${property::exists('b')}" message="'b' should not exist outside macro" />
+  </target>
+  
+  <target name="test-property-subst">
+    <macrodef name="property-subst">
+      <attributes>
+        <attribute name="a" />
+      </attributes>
+      <sequential>
+        <property name="actual_a" value="${a}" />
+        <property name="function_result" value="${bool::to-string(true)}" />
+      </sequential>
+    </macrodef>
+
+    <property name="myprop" value="a" />
+
+    <property-subst a="${myprop}" />
+    <assert-equals name="a" expected="a" actual="${actual_a}" />
+    <assert-equals name="function_result" expected="True" actual="${function_result}" />
+  </target>
+  
+  <target name="test-elements">
+    <macrodef name="macro-with-elements">
+      <elements>
+        <element name="element1" />
+      </elements>
+      <sequential>
+        <echo message="before element1" />
+        <element1/>
+        <echo message="after element1" />
+      </sequential>
+    </macrodef>
+
+    <macro-with-elements>
+      <element1>
+        <property name="element_executed" value="true" />
+      </element1>
+    </macro-with-elements>
+    <fail if="${element_executed != 'true'}" message="element_executed: expected true but was ${element_executed}" />
+  </target>
+
+  <target name="test-duplicate-macrodef">
+    <!-- should not fail if the same macro is included twice -->
+    <nant buildfile="duplicate.build" />
+    <nant buildfile="duplicate.build" />
+  </target>
+
+  <target name="test-duplicate-macrodef-redefinition">
+    <exec program="nant" commandline="/f:duplicate-redefinition.build" resultproperty="redefinition.failed" failonerror="false" />
+    <if test="${redefinition.failed == '0'}">
+      <fail message="Should have failed because we are trying to redefine an existing macro." />
+    </if>
+  </target>
+
+  <include buildfile="macrodefinitions.build" />
+  
+  <target name="test-element-from-different-context">
+    <elements-context-test>
+      <test-element>
+        <property name="test-element_executed" value="true" />
+        <echo message="This is a node from a different context" />
+      </test-element>
+    </elements-context-test>
+    <fail if="${test-element_executed != 'true'}" message="test-element_executed: expected true but was ${test-element_executed}" />
+  </target>
+  
+  <target name="test" depends="
+      test-macro-defined,
+      test-attributes,
+      test-properties-backedup,
+      test-property-subst,
+      test-elements,
+      test-duplicate-macrodef,
+      test-duplicate-macrodef-redefinition,
+      test-element-from-different-context
+      "/>
+  
 </project>
 


### PR DESCRIPTION
I gave the code a bit of a tidy-up, including updating conventions for .NET 4. 

I also changed the generated filenames to start with mdef_ rather than have that as a suffix, as it makes finding them in the temp folder much easier, and added the .NET runtime version that the macrodef was compiled with to the filename. This is because I hit a problem on our build agents where we have multiple versions of NAnt, and if the first NAnt to run on an agent was compiled with .NET 4, then this would cause all macrodefs to be compiled with .NET 4, which means that if an earlier version of NAnt then ran, it would try to use the pre-compiled macrodefs (since it only identified by hash), and then fail since the macrodefs were compiled with a later version of .NET. The changes I've made mean that different NAnt versions can now comfortably run side-by-side.
